### PR TITLE
Inserting #(squash) layer last

### DIFF
--- a/export_modification.go
+++ b/export_modification.go
@@ -27,7 +27,9 @@ func (e *Export) InsertLayer(parent string) (*Layer, error) {
 
 	// rewrite child json
 	child := e.ChildOf(parent)
-	child.LayerConfig.Parent = id
+	if child != nil {
+		child.LayerConfig.Parent = id
+	}
 
 	e.Layers[id] = entry
 
@@ -47,7 +49,8 @@ func (e *Export) ReplaceLayer(orig *Layer) error {
 	oldID := orig.LayerConfig.ID
 	child := e.ChildOf(oldID)
 
-	newLayer := &Layer{LayerConfig: orig.LayerConfig}
+	newLayer := orig.Clone()
+
 	newLayer.LayerConfig.Created = time.Now().UTC()
 	newLayer.LayerConfig.ID = newID
 
@@ -65,17 +68,4 @@ func (e *Export) ReplaceLayer(orig *Layer) error {
 	delete(e.Layers, oldID)
 
 	return nil
-}
-
-// RemoveLayer removes layer "l" and wires its parent to its child
-func (e *Export) RemoveLayer(l *Layer) {
-	layerID := l.LayerConfig.ID
-
-	debugf("  -  Removing %s. Squashed. (%s)\n", layerID[:12], l.Cmd())
-
-	child := e.ChildOf(layerID)
-	if child != nil {
-		e.Layers[child.LayerConfig.ID].LayerConfig.Parent = l.LayerConfig.Parent
-	}
-	delete(e.Layers, layerID)
 }

--- a/export_traversal.go
+++ b/export_traversal.go
@@ -11,7 +11,6 @@ func (e *Export) firstLayer(pattern string) *Layer {
 		if root == nil {
 			break
 		}
-
 		cmd := strings.Join(root.LayerConfig.ContainerConfig().Cmd, " ")
 		if strings.Contains(cmd, pattern) {
 			break
@@ -29,6 +28,22 @@ func (e *Export) FirstSquash() *Layer {
 // Root returns the top layer in the export
 func (e *Export) Root() *Layer {
 	return e.ChildOf("")
+}
+
+// Last returns the layer found last in the list
+func (e *Export) Last() *Layer {
+	current := e.Root()
+	for {
+		if current == nil {
+			break
+		}
+		child := e.ChildOf(current.LayerConfig.ID)
+		if child == nil {
+			break
+		}
+		current = child
+	}
+	return current
 }
 
 // ChildOf returns the child layer or nil of the parent

--- a/ingest_image_metadata.go
+++ b/ingest_image_metadata.go
@@ -116,7 +116,6 @@ func (e *Export) IngestImageMetadata(tarstream io.Reader) error {
 
 // populateFileData populates the layerToFiles as described above
 func (e *Export) populateFileData() error {
-
 	e.start = e.FirstSquash()
 
 	// Can't find a previously squashed layer, default to root

--- a/layer.go
+++ b/layer.go
@@ -36,3 +36,14 @@ func (l *Layer) Cmd() string {
 	}
 	return ret
 }
+
+// Clone returns a copy of layer l
+func (l *Layer) Clone() *Layer {
+	return &Layer{
+		LayerConfig:    l.LayerConfig,
+		DirHeader:      l.DirHeader,
+		VersionHeader:  l.VersionHeader,
+		JSONHeader:     l.JSONHeader,
+		LayerTarHeader: l.LayerTarHeader,
+	}
+}

--- a/layer_config.go
+++ b/layer_config.go
@@ -31,7 +31,8 @@ func NewLayerConfig(id, parent, comment string) *LayerConfig {
 	}
 }
 
-// ContainerConfig is a sub config of LayerConfig
+// ContainerConfig is a sub config of LayerConfig that represents the config
+// for the given layer only
 type ContainerConfig struct {
 	AttachStderr    bool
 	AttachStdin     bool
@@ -57,7 +58,7 @@ type ContainerConfig struct {
 	VolumesFrom     string
 }
 
-// Config is a sub config of LayerConfig
+// Config is a sub config of LayerConfig that represents the cumulative config
 type Config struct {
 	AttachStderr    bool
 	AttachStdin     bool


### PR DESCRIPTION
Previously, the squash layer was inserted immediately after the root. The reason for doing this initially was to follow the logic in the original `docker-squash` library for lack of a better place to start. However, now that this library reflects a better understand of the docker image format, it has become apparent that there is no real reason to insert the layer after the root.  Instead, inserting the layer at the end has the advantage of placing the layers in a more logical order.  The squash is the last operation done on the image, so putting the squash layer last instead of somewhere in the middle makes the image history less confusing.

Additionally, it is now possible to do multiple concecutive builds, squashing after each, and producing a working image.  Previously, the logic would have prevented any earlier squash layers from being
squashed into the new squash layer.

Finally, this pull request changes the process of rewriting the layer children.  Whereas previously the `ADD` and `RUN` layers were completely removed, now they are kept as-is except that their `layer.tar` is zeroed out.  This allows for the more accurate preservation of layer history, which is potentially useful for debugging purposes.
